### PR TITLE
Fix language names

### DIFF
--- a/language-study.list
+++ b/language-study.list
@@ -436,11 +436,11 @@ JavaScript 1.7
   2006
 JavaScript ES2015
   2015
-JavaScript ES2106
+JavaScript ES2016
   2016
-*JavaScript ES2107
+*JavaScript ES2017
   2017
-  JavaScript ES2106,C# 5.0
+  JavaScript ES2016,C# 5.0
 
 Lua
   1994


### PR DESCRIPTION
As discussed, fixing the following language names:

```diff
-ES2106
+ES2016
```

```diff
-ES2107
+ES2017
```